### PR TITLE
Added Warmup Match before gamemode to learn about user skills

### DIFF
--- a/main.py
+++ b/main.py
@@ -215,6 +215,23 @@ class MainWindow(QMainWindow):
             del self._quickplay_question_widget
         if hasattr(self, 'quickplay_container'):
             del self.quickplay_container
+
+        # Clean up any active warmup widgets
+        for attr in ('_warmup_intro_widget', '_warmup_question_widget', '_warmup_ranking_widget'):
+            widget = getattr(self, attr, None)
+            if widget:
+                try: widget.cleanup()
+                except Exception: pass
+                delattr(self, attr)
+        if hasattr(self, '_warmup_session'): del self._warmup_session
+        # Clean up game mode widgets
+        for attr in ('_gamemode_intro', 'game_mode_widget'):
+            widget = getattr(self, attr, None)
+            if widget:
+                try: widget.cleanup()
+                except Exception: pass
+                delattr(self, attr)
+        if hasattr(self, '_game_session_new'): del self._game_session_new
         
         self.init_ui()
         
@@ -496,63 +513,221 @@ class MainWindow(QMainWindow):
         self.play_sound("click-button.wav")
 
     def start_game_mode(self):
-        if hasattr(self, "game_mode_container"):
-            self.stack.setCurrentWidget(self.game_mode_container)
-            self.main_footer.show()      
-            self.section_footer.hide()   
-            back_btn = self.main_footer.findChild(QPushButton, tr("Back to Menu").lower().replace(" ", "_"))
-            if back_btn:
-                back_btn.show()
-            
-            # Bulletproof hide upload button in game mode starting phases
-            for btn in self.main_footer.findChildren(QPushButton):
-                 if "upload" in btn.objectName().lower() or "upload" in btn.text().lower():
-                     btn.hide()
-            return
+        """Entry point for Game Mode. Routes through warmup on first run."""
+        from question.warmup import has_completed_warmup
+        if not has_completed_warmup():
+            self._launch_warmup()
+        else:
+            self._launch_game_mode_intro()
 
-        self.game_mode_container = QWidget()
-        layout = QVBoxLayout()
-        layout.setAlignment(Qt.AlignCenter)
-        self.game_mode_container.setLayout(layout)
+    # ── Warmup launch helpers ────────────────────────────────────────────────
 
-        title_label = QLabel(tr("Select Game Difficulty"))
-        title_label.setAlignment(Qt.AlignCenter)
-        title_label.setProperty("class", "main-title")
-        layout.addWidget(title_label)
-        layout.addSpacing(10) #
-        difficulties = [(tr("Easy"), 1), (tr("Medium"), 2), (tr("Hard"), 3), (tr("Extra Hard"), 4)]
-        for text, index in difficulties:
-            btn = QPushButton(text)
-            btn.setMinimumSize(260, 70)
-            btn.setProperty("class", "menu-button")
-            btn.setProperty("theme", self.current_theme)
-            btn.clicked.connect(lambda _, idx=index: self.load_game_questions(idx))
-            btn.setAccessibleName(f"{text} difficulty")
-            btn.setAccessibleDescription(f"Start game at {text} difficulty level")
-            layout.addWidget(btn)
+    def _launch_warmup(self):
+        """Show the warmup intro screen (first-time Game Mode)."""
+        from pages.warmup_ui import WarmupIntroWidget
+        from pages.shared_ui import apply_theme
+        if hasattr(self, 'tts'):
+            self.tts.stop()
 
-        mole_label = QLabel()
-        mole_label.setPixmap(QPixmap("assets/mole.png").scaled(120, 120, Qt.KeepAspectRatio, Qt.SmoothTransformation))
-        mole_label.setAlignment(Qt.AlignCenter)
-        mole_label.setAccessibleName("")
-        mole_label.setAccessibleDescription("")
-        layout.addWidget(mole_label)
-
-        self.stack.addWidget(self.game_mode_container)
-        self.stack.setCurrentWidget(self.game_mode_container)
+        self._warmup_intro_widget = WarmupIntroWidget(
+            on_begin=self._begin_warmup_questions,
+            window=self,
+            tts=self.tts,
+        )
+        apply_theme(self._warmup_intro_widget, self.current_theme)
+        self.stack.addWidget(self._warmup_intro_widget)
+        self.stack.setCurrentWidget(self._warmup_intro_widget)
 
         self.main_footer.show()
-        self.section_footer.hide()   
+        self.section_footer.hide()
         back_btn = self.main_footer.findChild(QPushButton, tr("Back to Menu").lower().replace(" ", "_"))
         if back_btn:
             back_btn.show()
-
-        # Bulletproof hide upload button in game mode starting phases
         for btn in self.main_footer.findChildren(QPushButton):
-             if "upload" in btn.objectName().lower() or "upload" in btn.text().lower():
-                 btn.hide()
+            if "upload" in btn.objectName().lower() or "upload" in btn.text().lower():
+                btn.hide()
 
-        apply_theme(self.game_mode_container, self.current_theme)
+    def _begin_warmup_questions(self):
+        """Transition from intro screen to the question widget."""
+        from question.warmup import WarmupSession
+        from pages.warmup_ui import WarmupQuestionWidget
+        from pages.shared_ui import apply_theme
+
+        self._warmup_session = WarmupSession()
+        self._warmup_question_widget = WarmupQuestionWidget(
+            session=self._warmup_session,
+            window=self,
+            tts=self.tts,
+            on_complete=self._show_warmup_ranking,
+        )
+        apply_theme(self._warmup_question_widget, self.current_theme)
+        self.stack.addWidget(self._warmup_question_widget)
+        self.stack.setCurrentWidget(self._warmup_question_widget)
+
+        # Hide footer during active questioning
+        self.main_footer.hide()
+        self.section_footer.hide()
+
+    def _show_warmup_ranking(self):
+        """Save profile and show the ranked results screen."""
+        from pages.warmup_ui import WarmupRankingWidget
+        from pages.shared_ui import apply_theme
+        from question.warmup import save_warmup_profile
+
+        if hasattr(self, '_warmup_question_widget'):
+            self._warmup_question_widget.cleanup()
+
+        ranked = self._warmup_session.get_ranked_results()
+        save_warmup_profile(ranked)
+        print(f"[WARMUP] Profile saved. Top skill: {ranked[0]['label'] if ranked else 'N/A'}")
+
+        self._warmup_ranking_widget = WarmupRankingWidget(
+            session=self._warmup_session,
+            window=self,
+            tts=self.tts,
+            on_continue=self._on_warmup_complete,
+        )
+        apply_theme(self._warmup_ranking_widget, self.current_theme)
+        self.stack.addWidget(self._warmup_ranking_widget)
+        self.stack.setCurrentWidget(self._warmup_ranking_widget)
+
+        self.main_footer.show()
+        self.section_footer.hide()
+        back_btn = self.main_footer.findChild(QPushButton, tr("Back to Menu").lower().replace(" ", "_"))
+        if back_btn:
+            back_btn.show()
+        for btn in self.main_footer.findChildren(QPushButton):
+            if "upload" in btn.objectName().lower() or "upload" in btn.text().lower():
+                btn.hide()
+
+    def _on_warmup_complete(self):
+        """Called when user presses Continue on the ranking screen."""
+        if hasattr(self, '_warmup_ranking_widget'):
+            self._warmup_ranking_widget.cleanup()
+        self._launch_game_mode_intro()
+
+    # ── Game Mode (adaptive) ────────────────────────────────────────────────
+
+    def _launch_game_mode_intro(self):
+        """Show the brief intro screen before starting a game session."""
+        from pages.warmup_ui import GameModeIntroWidget
+        from pages.shared_ui import apply_theme
+        from question.warmup import load_warmup_profile, load_game_session
+        if hasattr(self, 'tts'): self.tts.stop()
+
+        ranked      = load_warmup_profile()
+        saved_state = load_game_session()
+
+        self._gamemode_intro = GameModeIntroWidget(
+            ranked=ranked, saved_state=saved_state,
+            on_start=self._start_game_session,
+            window=self, tts=self.tts,
+        )
+        apply_theme(self._gamemode_intro, self.current_theme)
+        self.stack.addWidget(self._gamemode_intro)
+        self.stack.setCurrentWidget(self._gamemode_intro)
+
+        self.main_footer.show(); self.section_footer.hide()
+        back_btn = self.main_footer.findChild(QPushButton, tr("Back to Menu").lower().replace(" ", "_"))
+        if back_btn: back_btn.show()
+        for btn in self.main_footer.findChildren(QPushButton):
+            if "upload" in btn.objectName().lower() or "upload" in btn.text().lower():
+                btn.hide()
+
+    def _start_game_session(self):
+        """Create GameModeSession + GameModeWidget, start 90s timer."""
+        from question.warmup import GameModeSession, load_warmup_profile, load_game_session
+        from pages.warmup_ui import GameModeWidget
+        from pages.shared_ui import apply_theme
+        if hasattr(self, 'tts'): self.tts.stop()
+
+        ranked      = load_warmup_profile() or []
+        saved_state = load_game_session()
+
+        self._game_session_new = GameModeSession(ranked, saved_state)
+        self.time_remaining    = self._game_session_new.session_time
+        self.game_active       = True
+
+        # Reuse or create game page container
+        if not hasattr(self, 'game_page_container'):
+            self.game_page_container = QWidget()
+            self.game_page_layout    = QVBoxLayout(self.game_page_container)
+            self.game_page_layout.setContentsMargins(0, 0, 0, 0)
+            self.stack.addWidget(self.game_page_container)
+        for i in reversed(range(self.game_page_layout.count())):
+            w = self.game_page_layout.itemAt(i).widget()
+            if w: w.setParent(None)
+
+        self.game_mode_widget = GameModeWidget(
+            session=self._game_session_new,
+            window=self, tts=self.tts,
+            on_session_end=self._on_game_mode_end,
+        )
+        apply_theme(self.game_mode_widget, self.current_theme)
+        self.game_page_layout.addWidget(self.game_mode_widget)
+        self.stack.setCurrentWidget(self.game_page_container)
+
+        self.main_footer.hide(); self.section_footer.show()
+        back_ops = self.section_footer.findChild(QPushButton, "back_to_operations")
+        if back_ops: back_ops.hide()
+        back_learn = self.section_footer.findChild(QPushButton, "back_to_learn")
+        if back_learn: back_learn.hide()
+        for btn in self.section_footer.findChildren(QPushButton):
+            if "upload" in btn.objectName().lower() or "upload" in btn.text().lower():
+                btn.hide()
+
+        self._original_back_to_home = self.back_to_home
+        def safe_back():
+            if hasattr(self, 'game_timer') and self.game_timer.isActive(): self.game_timer.stop()
+            self.game_active = False
+            if hasattr(self, 'tts'): self.tts.stop()
+            if hasattr(self, 'game_mode_widget'): self.game_mode_widget.cleanup()
+            if hasattr(self, '_original_back_to_home'): self.back_to_home = self._original_back_to_home
+            self.back_to_main_menu()
+        self.back_to_home = safe_back
+
+        if hasattr(self, 'tts') and not self.is_muted:
+            QTimer.singleShot(300, lambda: self.tts.speak(tr("Game mode! Let's go!")))
+
+        self.game_timer.start()
+
+    def _on_game_mode_end(self):
+        """Called by GameModeWidget when session finishes (timer or no more questions)."""
+        if not self.game_active: return
+        self.game_active = False
+        self.game_timer.stop()
+        if hasattr(self, 'tts'): self.tts.stop()
+        if hasattr(self, '_original_back_to_home'): self.back_to_home = self._original_back_to_home
+
+        from question.warmup import save_warmup_profile, clear_game_session
+        # Update and persist ranking
+        updated = self._game_session_new.get_ranked_results_updated()
+        save_warmup_profile(updated)
+        clear_game_session()
+        print(f"[GAME] Session ended. Q={self._game_session_new.question_count} Acc={self._game_session_new.accuracy_pct()}%")
+
+        QTimer.singleShot(500, lambda: self.tts.speak(tr("Time's up! Amazing effort.")))
+        QTimer.singleShot(2200, self._show_game_report)
+
+    def _show_game_report(self):
+        from pages.warmup_ui import GameModeReportWidget
+        from pages.shared_ui import apply_theme
+        report = GameModeReportWidget(
+            session=self._game_session_new, window=self, tts=self.tts,
+            on_play_again=self._on_game_play_again,
+        )
+        apply_theme(report, self.current_theme)
+        self.stack.addWidget(report)
+        self.stack.setCurrentWidget(report)
+        self.section_footer.hide(); self.main_footer.show()
+        back_btn = self.main_footer.findChild(QPushButton, tr("Back to Menu").lower().replace(" ", "_"))
+        if back_btn: back_btn.show()
+        for btn in self.main_footer.findChildren(QPushButton):
+            if "upload" in btn.objectName().lower() or "upload" in btn.text().lower(): btn.hide()
+
+    def _on_game_play_again(self):
+        """Play Again from report: start a fresh session."""
+        self._launch_game_mode_intro()
 
     def load_game_questions(self, difficulty_index):
         from question.loader import LinearProgressionSession, QuestionProcessor
@@ -701,25 +876,6 @@ class MainWindow(QMainWindow):
             self._back_to_diff_btn.setParent(None)
             self._back_to_diff_btn = None
 
-    def _back_to_difficulty(self):
-        if hasattr(self, 'game_timer') and self.game_timer.isActive():
-            self.game_timer.stop()
-        if hasattr(self, 'game_active'):
-            self.game_active = False
-        if hasattr(self, 'tts'):
-            self.tts.stop()
-        if hasattr(self, 'question_widget'):
-            self.question_widget.stop_all_activity()
-        if hasattr(self, '_original_back_to_home'):
-            self.back_to_home = self._original_back_to_home
-        self._cleanup_game_footer()
-        
-        self.stack.setCurrentWidget(self.game_mode_container)
-        self.main_footer.hide()
-        self.section_footer.show()
-        back_ops = self.section_footer.findChild(QPushButton, "back_operations")
-        if back_ops: back_ops.hide()
-
     def _update_timer_bar(self):
         self.timer_bar.setValue(self.time_remaining)
         if self.time_remaining > 30:
@@ -746,17 +902,23 @@ class MainWindow(QMainWindow):
 
     def _on_game_tick(self):
         self.time_remaining -= 1
-        self._update_timer_bar()
-        
-        from language.language import tr
+        # Delegate timer display to the active game widget
+        if hasattr(self, 'game_mode_widget') and self.game_mode_widget:
+            try: self.game_mode_widget.update_timer(self.time_remaining)
+            except Exception: pass
+        elif hasattr(self, 'timer_bar'):
+            self._update_timer_bar()
 
+        from language.language import tr
         if self.time_remaining == 15:
-            self.game_session.set_finale()
             self.tts.speak(tr("Keep going!"))
         elif self.time_remaining == 5:
             self.tts.speak(tr("One more!"))
         elif self.time_remaining <= 0:
-            self._end_game_session()
+            if hasattr(self, 'game_mode_widget') and self.game_mode_widget:
+                self._on_game_mode_end()
+            else:
+                self._end_game_session()
 
     def _end_game_session(self):
         if not self.game_active:
@@ -1010,7 +1172,17 @@ class MainWindow(QMainWindow):
         self.update_back_to_operations_visibility(name)
     
     def back_to_main_menu(self):
-        self.top_bar.show()  
+        self.top_bar.show()
+
+        # Stop any active warmup activity (timers / TTS inside warmup widgets)
+        for attr in ('_warmup_question_widget', '_warmup_intro_widget', '_warmup_ranking_widget'):
+            widget = getattr(self, attr, None)
+            if widget:
+                try:
+                    widget.cleanup()
+                except Exception:
+                    pass
+
         current_page = self.stack.currentWidget()
         if current_page:
             question_widget = current_page.findChild(QuestionWidget)
@@ -1021,7 +1193,7 @@ class MainWindow(QMainWindow):
             self.tts.stop()
             self.tts.reset()
         self.play_sound("home_button_sound.wav")
-        self.stack.setCurrentWidget(self.startup_widget)  
+        self.stack.setCurrentWidget(self.startup_widget)
         self.section_footer.hide()
         self.main_footer.show()
         

--- a/pages/warmup_ui.py
+++ b/pages/warmup_ui.py
@@ -1,0 +1,856 @@
+"""pages/warmup_ui.py
+
+Three QWidget screens for the Warmup Match flow:
+  WarmupIntroWidget       — intro / explanation screen
+  WarmupQuestionWidget    — question presenter (all 13 steps in one widget)
+  WarmupRankingWidget     — post-warmup ranked results screen
+"""
+
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QLineEdit, QProgressBar, QSizePolicy, QScrollArea, QFrame,
+    QSpacerItem
+)
+from PyQt5.QtCore import Qt, QTimer, QRegExp
+from PyQt5.QtGui import QFont, QRegExpValidator
+from time import time
+
+from question.warmup import (
+    SCORE_INFO, AUTO_SKIP_SECONDS, WarmupSession
+)
+from language.language import tr
+
+
+# ---------------------------------------------------------------------------
+# Colour palette (score → hex) — used on ranking rows
+# ---------------------------------------------------------------------------
+SCORE_COLOURS = {1.0: "#27AE60", 0.5: "#D4AC0D", 0.2: "#E67E22", 0.0: "#95A5A6"}
+
+
+# ---------------------------------------------------------------------------
+# WarmupIntroWidget
+# ---------------------------------------------------------------------------
+
+class WarmupIntroWidget(QWidget):
+    """
+    Intro/explanation screen shown before the warmup questions begin.
+    Calls on_begin() when the user presses "Begin Warmup".
+    """
+
+    def __init__(self, on_begin, window, tts):
+        super().__init__()
+        self.on_begin   = on_begin
+        self.window     = window
+        self.tts        = tts
+        self.setAccessibleName("Warmup Match Introduction")
+        self._init_ui()
+        self._speak_intro()
+
+    def _init_ui(self):
+        layout = QVBoxLayout()
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setSpacing(18)
+        layout.setContentsMargins(50, 30, 50, 30)
+        self.setLayout(layout)
+
+        layout.addStretch()
+
+        title = QLabel("🏁 " + tr("Warmup Match"))
+        title.setAlignment(Qt.AlignCenter)
+        title.setProperty("class", "main-title")
+        title.setAccessibleName("Warmup Match")
+        layout.addWidget(title)
+
+        layout.addSpacing(10)
+
+        desc = QLabel(
+            "Welcome! Before we begin the real game, let's do a quick "
+            "Warmup Match so we can understand your strengths.\n\n"
+            "You will answer one question from each of the 13 question types, "
+            "starting from the easiest. Your speed and accuracy are measured "
+            "after the question is read aloud.\n\n"
+            "The warmup ends early only if you miss or skip too many questions."
+        )
+        desc.setAlignment(Qt.AlignCenter)
+        desc.setWordWrap(True)
+        desc.setProperty("class", "subtitle")
+        desc.setMaximumWidth(560)
+        layout.addWidget(desc, alignment=Qt.AlignCenter)
+
+        layout.addSpacing(20)
+
+        # Info row
+        info_row = QHBoxLayout()
+        info_row.setAlignment(Qt.AlignCenter)
+        info_row.setSpacing(30)
+        for icon, label_text in [("⏱️", "Speed matters"), ("🎯", "13 question types"), ("📊", "Ranked results")]:
+            col = QVBoxLayout()
+            col.setAlignment(Qt.AlignCenter)
+            ico = QLabel(icon)
+            ico.setAlignment(Qt.AlignCenter)
+            ico.setFont(QFont("Arial", 22))
+            ico.setAccessibleName("")
+            lbl = QLabel(label_text)
+            lbl.setAlignment(Qt.AlignCenter)
+            lbl.setProperty("class", "subtitle")
+            col.addWidget(ico)
+            col.addWidget(lbl)
+            w = QWidget()
+            w.setLayout(col)
+            info_row.addWidget(w)
+        layout.addLayout(info_row)
+
+        layout.addSpacing(25)
+
+        self.begin_btn = QPushButton("🚀  Begin Warmup")
+        self.begin_btn.setMinimumSize(260, 70)
+        self.begin_btn.setProperty("class", "menu-button")
+        self.begin_btn.setAccessibleName("Begin Warmup")
+        self.begin_btn.setAccessibleDescription(
+            "Start the warmup match. You will answer 13 questions."
+        )
+        self.begin_btn.clicked.connect(self._on_begin)
+        layout.addWidget(self.begin_btn, alignment=Qt.AlignCenter)
+
+        layout.addStretch()
+
+        QTimer.singleShot(200, self.begin_btn.setFocus)
+
+    def _speak_intro(self):
+        if self.window and not self.window.is_muted and self.tts:
+            msg = (
+                "Welcome to the Warmup Match! "
+                "We will assess your strengths by asking one question from each type. "
+                "Press Begin Warmup when you are ready."
+            )
+            QTimer.singleShot(400, lambda: self.tts.speak(msg))
+
+    def _on_begin(self):
+        if self.tts:
+            self.tts.stop()
+        self.on_begin()
+
+    def cleanup(self):
+        if self.tts:
+            self.tts.stop()
+
+
+# ---------------------------------------------------------------------------
+# WarmupQuestionWidget
+# ---------------------------------------------------------------------------
+
+class WarmupQuestionWidget(QWidget):
+    """
+    Handles all 13 warmup steps inside a single persistent widget.
+    Reloads its own content for each new step without being replaced.
+    """
+
+    def __init__(self, session: WarmupSession, window, tts, on_complete):
+        super().__init__()
+        self.session       = session
+        self.window        = window
+        self.tts           = tts
+        self.on_complete   = on_complete
+
+        self._active              = True
+        self._question_start_time = None
+        self._current_answer      = None
+        self._current_question_text = ""
+
+        self.setAccessibleName("Warmup Question")
+        self._init_ui()
+        self._load_current_step()
+
+    # ── UI setup ─────────────────────────────────────────────────────────────
+
+    def _init_ui(self):
+        root = QVBoxLayout()
+        root.setContentsMargins(30, 10, 30, 10)
+        root.setSpacing(8)
+        self.setLayout(root)
+
+        # Header row: title + step counter
+        header = QHBoxLayout()
+        warmup_lbl = QLabel("🏁 Warmup Match")
+        warmup_lbl.setProperty("class", "subtitle")
+        warmup_lbl.setAccessibleName("")
+        header.addWidget(warmup_lbl, alignment=Qt.AlignLeft)
+
+        self.step_counter_lbl = QLabel("")
+        self.step_counter_lbl.setProperty("class", "subtitle")
+        self.step_counter_lbl.setAlignment(Qt.AlignRight)
+        header.addWidget(self.step_counter_lbl, alignment=Qt.AlignRight)
+        root.addLayout(header)
+
+        # Progress bar
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setMinimum(0)
+        self.progress_bar.setMaximum(self.session.total_steps())
+        self.progress_bar.setValue(0)
+        self.progress_bar.setTextVisible(False)
+        self.progress_bar.setFixedHeight(10)
+        self.progress_bar.setAccessibleName("")
+        self.progress_bar.setAccessibleDescription("")
+        root.addWidget(self.progress_bar)
+
+        # Question type label
+        self.type_lbl = QLabel("")
+        self.type_lbl.setAlignment(Qt.AlignCenter)
+        self.type_lbl.setProperty("class", "main-title")
+        root.addWidget(self.type_lbl)
+
+        root.addStretch(1)
+
+        # Question text
+        self.question_lbl = QLabel("")
+        self.question_lbl.setAlignment(Qt.AlignCenter)
+        self.question_lbl.setWordWrap(True)
+        self.question_lbl.setProperty("class", "question-label")
+        self.question_lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        root.addWidget(self.question_lbl)
+
+        root.addStretch(1)
+
+        # Auto-skip timer bar
+        self.autoskip_bar = QProgressBar()
+        self.autoskip_bar.setMinimum(0)
+        self.autoskip_bar.setMaximum(AUTO_SKIP_SECONDS)
+        self.autoskip_bar.setValue(AUTO_SKIP_SECONDS)
+        self.autoskip_bar.setTextVisible(True)
+        self.autoskip_bar.setFormat("Auto-skip in %vs")
+        self.autoskip_bar.setFixedHeight(18)
+        self.autoskip_bar.setVisible(False)
+        self.autoskip_bar.setAccessibleName("")
+        root.addWidget(self.autoskip_bar)
+
+        # Input row
+        input_row = QHBoxLayout()
+        input_row.setSpacing(10)
+        input_row.setAlignment(Qt.AlignCenter)
+
+        self.input_box = QLineEdit()
+        self.input_box.setMinimumSize(220, 55)
+        self.input_box.setMaximumWidth(320)
+        self.input_box.setAlignment(Qt.AlignCenter)
+        self.input_box.setPlaceholderText(tr("Enter your answer"))
+        self.input_box.setFont(QFont("Arial", 16))
+        self.input_box.setProperty("class", "answer-input")
+        self.input_box.setAccessibleName(tr("Answer input"))
+        validator = QRegExpValidator(QRegExp(r"-?\d*\.?\d*"))
+        self.input_box.setValidator(validator)
+        self.input_box.returnPressed.connect(self._check_answer)
+        input_row.addWidget(self.input_box)
+
+        self.submit_btn = QPushButton("✓  Submit")
+        self.submit_btn.setMinimumSize(120, 55)
+        self.submit_btn.setProperty("class", "menu-button")
+        self.submit_btn.setAccessibleName("Submit answer")
+        self.submit_btn.clicked.connect(self._check_answer)
+        input_row.addWidget(self.submit_btn)
+
+        root.addLayout(input_row)
+
+        root.addSpacing(10)
+
+        # Skip button (always visible, prominent)
+        self.skip_btn = QPushButton("⏭  Skip this question")
+        self.skip_btn.setMinimumSize(200, 48)
+        self.skip_btn.setProperty("class", "footer-button")
+        self.skip_btn.setFont(QFont("Arial", 13))
+        self.skip_btn.setAccessibleName("Skip this question")
+        self.skip_btn.setAccessibleDescription(
+            "Skip the current question. Skipped questions score zero."
+        )
+        self.skip_btn.clicked.connect(self._on_skip)
+        root.addWidget(self.skip_btn, alignment=Qt.AlignCenter)
+
+        # Feedback label
+        self.feedback_lbl = QLabel("")
+        self.feedback_lbl.setAlignment(Qt.AlignCenter)
+        self.feedback_lbl.setFont(QFont("Arial", 22, QFont.Bold))
+        self.feedback_lbl.setFixedHeight(50)
+        root.addWidget(self.feedback_lbl)
+
+        root.addStretch(1)
+
+        # Timers
+        self.autoskip_timer = QTimer(self)
+        self.autoskip_timer.setSingleShot(True)
+        self.autoskip_timer.setInterval(AUTO_SKIP_SECONDS * 1000)
+        self.autoskip_timer.timeout.connect(self._on_autoskip)
+
+        self.autoskip_tick_timer = QTimer(self)
+        self.autoskip_tick_timer.setInterval(1000)
+        self.autoskip_tick_timer.timeout.connect(self._on_autoskip_tick)
+
+        self._autoskip_remaining = AUTO_SKIP_SECONDS
+
+    # ── Step loading ─────────────────────────────────────────────────────────
+
+    def _load_current_step(self):
+        if not self._active:
+            return
+        if self.session.is_complete():
+            self._finish()
+            return
+
+        # Stop stale timers
+        self.autoskip_timer.stop()
+        self.autoskip_tick_timer.stop()
+        self.autoskip_bar.setVisible(False)
+
+        step = self.session.current_step()
+        step_num = self.session.step_index + 1
+        total    = self.session.total_steps()
+
+        # Update progress UI
+        self.step_counter_lbl.setText(f"Question {step_num} / {total}")
+        self.progress_bar.setValue(self.session.step_index)
+        self.type_lbl.setText(step["label"])
+        self.feedback_lbl.setText("")
+        self.input_box.clear()
+        self.input_box.setEnabled(True)
+        self.submit_btn.setEnabled(True)
+        self.skip_btn.setEnabled(True)
+
+        # Build processor and get question
+        processor = self.session.get_current_processor()
+        if processor is None or (processor.df is not None and processor.df.empty):
+            # No data for this step → auto-skip silently
+            self.session.skip_question()
+            QTimer.singleShot(0, self._load_current_step)
+            return
+
+        question_text, self._current_answer = processor.get_questions()
+        self._current_question_text = question_text
+
+        if question_text == "No questions found." or self._current_answer is None:
+            self.session.skip_question()
+            QTimer.singleShot(0, self._load_current_step)
+            return
+
+        # Adjust font size by length
+        length = len(question_text)
+        if length > 120:
+            self.question_lbl.setStyleSheet("font-size: 14pt;")
+        elif length > 80:
+            self.question_lbl.setStyleSheet("font-size: 18pt;")
+        else:
+            self.question_lbl.setStyleSheet("")
+
+        self.question_lbl.setText(question_text)
+
+        # TTS + deferred timer start
+        self._question_start_time = None
+        audio_on = self.window and not self.window.is_muted
+
+        if audio_on and self.tts:
+            tts_text = f"{question_text}. {tr('Type your answer')}"
+            delay_ms = len(tts_text) * 70 + 1500
+            self.tts.speak(tts_text)
+            QTimer.singleShot(delay_ms, self._on_tts_done)
+        else:
+            self._on_tts_done()
+
+        QTimer.singleShot(100, self.input_box.setFocus)
+
+    def _on_tts_done(self):
+        if not self._active:
+            return
+        self._question_start_time = time()
+        self._autoskip_remaining  = AUTO_SKIP_SECONDS
+        self.autoskip_bar.setValue(AUTO_SKIP_SECONDS)
+        self.autoskip_bar.setVisible(True)
+        self.autoskip_timer.start()
+        self.autoskip_tick_timer.start()
+
+    def _on_autoskip_tick(self):
+        self._autoskip_remaining = max(0, self._autoskip_remaining - 1)
+        self.autoskip_bar.setValue(self._autoskip_remaining)
+
+    # ── Answer handling ──────────────────────────────────────────────────────
+
+    def _check_answer(self):
+        if not self._active:
+            return
+        self._stop_timers()
+
+        user_text = self.input_box.text().strip()
+        if not user_text:
+            self.input_box.setFocus()
+            return
+
+        try:
+            user_val    = float(user_text)
+            correct_val = float(self._current_answer)
+            is_correct  = (user_val == correct_val)
+        except (TypeError, ValueError):
+            self.feedback_lbl.setText('<span style="color:#E74C3C;">✗ Invalid — try again</span>')
+            self.input_box.setFocus()
+            return
+
+        elapsed = (time() - self._question_start_time) if self._question_start_time else 0.0
+        score   = self.session.submit_answer(is_correct, elapsed)
+
+        self.input_box.setEnabled(False)
+        self.submit_btn.setEnabled(False)
+        self.skip_btn.setEnabled(False)
+
+        if is_correct:
+            emoji, label = SCORE_INFO.get(score, ("✓", ""))
+            self.feedback_lbl.setText(
+                f'<span style="color:#27AE60; font-size:22pt;">{emoji} Correct!  {label}</span>'
+            )
+            if self.tts and self.window and not self.window.is_muted:
+                QTimer.singleShot(50, lambda: self.tts.speak(f"Correct! {label}"))
+            QTimer.singleShot(1400, self._advance)
+        else:
+            self.feedback_lbl.setText(
+                f'<span style="color:#E74C3C; font-size:22pt;">✗ Wrong — moving on</span>'
+            )
+            if self.tts and self.window and not self.window.is_muted:
+                QTimer.singleShot(50, lambda: self.tts.speak("Wrong."))
+            QTimer.singleShot(1200, self._advance)
+
+    def _on_skip(self):
+        if not self._active:
+            return
+        self._stop_timers()
+        self.session.skip_question()
+        self.input_box.setEnabled(False)
+        self.submit_btn.setEnabled(False)
+        self.skip_btn.setEnabled(False)
+        self.feedback_lbl.setText('<span style="color:#95A5A6; font-size:18pt;">⏭ Skipped</span>')
+        QTimer.singleShot(800, self._advance)
+
+    def _on_autoskip(self):
+        if not self._active:
+            return
+        self.autoskip_tick_timer.stop()
+        self.autoskip_bar.setValue(0)
+        self.session.skip_question()
+        self.input_box.setEnabled(False)
+        self.submit_btn.setEnabled(False)
+        self.skip_btn.setEnabled(False)
+        self.feedback_lbl.setText('<span style="color:#95A5A6; font-size:18pt;">⏱ Time out — auto-skipped</span>')
+        QTimer.singleShot(1000, self._advance)
+
+    def _advance(self):
+        if not self._active:
+            return
+        if self.session.is_complete():
+            self._finish()
+        else:
+            self._load_current_step()
+
+    def _finish(self):
+        self._active = False
+        self._stop_timers()
+        self.on_complete()
+
+    # ── Utilities ────────────────────────────────────────────────────────────
+
+    def _stop_timers(self):
+        self.autoskip_timer.stop()
+        self.autoskip_tick_timer.stop()
+        self.autoskip_bar.setVisible(False)
+
+    def cleanup(self):
+        self._active = False
+        self._stop_timers()
+        if self.tts:
+            self.tts.stop()
+
+
+# ---------------------------------------------------------------------------
+# WarmupRankingWidget
+# ---------------------------------------------------------------------------
+
+class WarmupRankingWidget(QWidget):
+    """
+    Post-warmup screen that displays ranked results and offers a
+    "Continue to Game Mode" button.
+    """
+
+    def __init__(self, session: WarmupSession, window, tts, on_continue):
+        super().__init__()
+        self.session     = session
+        self.window      = window
+        self.tts         = tts
+        self.on_continue = on_continue
+        self.setAccessibleName("Warmup Results")
+        self._init_ui()
+        self._speak_results()
+
+    def _init_ui(self):
+        root = QVBoxLayout()
+        root.setContentsMargins(40, 20, 40, 20)
+        root.setSpacing(12)
+        self.setLayout(root)
+
+        # Title
+        title = QLabel("🏆 Warmup Complete!")
+        title.setAlignment(Qt.AlignCenter)
+        title.setProperty("class", "main-title")
+        title.setAccessibleName("Warmup Complete")
+        root.addWidget(title)
+
+        # Summary line
+        ranked   = self.session.get_ranked_results()
+        total    = len(ranked)
+        correct  = self.session.correct_count()
+        reason   = self.session.completion_reason()
+
+        if reason == "wrong":
+            summary_text = f"You answered {correct}/{total} questions correctly. The warmup ended early — that's okay!"
+        elif reason == "skipped":
+            summary_text = f"You answered {correct}/{total} questions. The warmup ended after too many skips — no worries!"
+        else:
+            summary_text = f"Great job completing all {total} questions! You got {correct} correct."
+
+        summary = QLabel(summary_text)
+        summary.setAlignment(Qt.AlignCenter)
+        summary.setWordWrap(True)
+        summary.setProperty("class", "subtitle")
+        summary.setAccessibleName(summary_text)
+        root.addWidget(summary)
+
+        divider = QFrame()
+        divider.setFrameShape(QFrame.HLine)
+        divider.setFrameShadow(QFrame.Sunken)
+        root.addWidget(divider)
+
+        # Scrollable ranking list
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.NoFrame)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
+        list_widget = QWidget()
+        list_layout = QVBoxLayout(list_widget)
+        list_layout.setSpacing(6)
+        list_layout.setContentsMargins(0, 0, 0, 0)
+
+        for rank, entry in enumerate(ranked, start=1):
+            label_text = entry["label"]
+            score      = entry["score"]
+            emoji, tier_name = SCORE_INFO.get(score, ("?", "Unknown"))
+            colour = SCORE_COLOURS.get(score, "#95A5A6")
+
+            row = QHBoxLayout()
+            row.setSpacing(12)
+
+            rank_lbl = QLabel(f"#{rank}")
+            rank_lbl.setFixedWidth(36)
+            rank_lbl.setFont(QFont("Arial", 13, QFont.Bold))
+            rank_lbl.setAlignment(Qt.AlignCenter)
+            row.addWidget(rank_lbl)
+
+            type_lbl = QLabel(label_text)
+            type_lbl.setFont(QFont("Arial", 13))
+            type_lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+            row.addWidget(type_lbl)
+
+            pts_lbl = QLabel(f"{emoji}  {tier_name}  ({score:.1f} pt{'s' if score != 1.0 else ''})")
+            pts_lbl.setFont(QFont("Arial", 13, QFont.Bold))
+            pts_lbl.setAlignment(Qt.AlignRight)
+            pts_lbl.setStyleSheet(f"color: {colour};")
+            pts_lbl.setAccessibleName(f"{label_text}: {tier_name}, {score} points")
+            row.addWidget(pts_lbl)
+
+            row_widget = QWidget()
+            row_widget.setLayout(row)
+            row_widget.setStyleSheet(
+                "QWidget { border-bottom: 1px solid rgba(128,128,128,0.2); padding: 4px 0; }"
+            )
+            list_layout.addWidget(row_widget)
+
+        list_layout.addStretch()
+        scroll.setWidget(list_widget)
+        root.addWidget(scroll)
+
+        root.addSpacing(8)
+
+        # Continue button
+        self.continue_btn = QPushButton("▶  Continue to Game Mode")
+        self.continue_btn.setMinimumSize(280, 70)
+        self.continue_btn.setProperty("class", "menu-button")
+        self.continue_btn.setAccessibleName("Continue to Game Mode")
+        self.continue_btn.setAccessibleDescription(
+            "Proceed to the Game Mode difficulty selector."
+        )
+        self.continue_btn.clicked.connect(self._on_continue)
+        root.addWidget(self.continue_btn, alignment=Qt.AlignCenter)
+
+        QTimer.singleShot(300, self.continue_btn.setFocus)
+
+    def _speak_results(self):
+        if not (self.window and not self.window.is_muted and self.tts):
+            return
+        ranked = self.session.get_ranked_results()
+        if not ranked:
+            return
+        top = ranked[0]
+        emoji, tier = SCORE_INFO.get(top["score"], ("", ""))
+        msg = (
+            f"Warmup complete! Your top skill is {top['label']} — {tier}. "
+            f"Press Continue to start the Game Mode."
+        )
+        QTimer.singleShot(600, lambda: self.tts.speak(msg))
+        focus_delay = 600 + len(msg) * 65 + 500
+        QTimer.singleShot(focus_delay, self.continue_btn.setFocus)
+
+    def _on_continue(self):
+        if self.tts:
+            self.tts.stop()
+        self.on_continue()
+
+    def cleanup(self):
+        if self.tts:
+            self.tts.stop()
+
+
+# ---------------------------------------------------------------------------
+# GameModeIntroWidget
+# ---------------------------------------------------------------------------
+
+class GameModeIntroWidget(QWidget):
+    """Brief intro/resume screen shown before each Game Mode session."""
+
+    def __init__(self, ranked, saved_state, on_start, window, tts):
+        super().__init__()
+        self.ranked = ranked or []; self.saved_state = saved_state
+        self.on_start = on_start; self.window = window; self.tts = tts
+        self.setAccessibleName("Game Mode Introduction")
+        self._init_ui(); self._speak_intro()
+
+    def _init_ui(self):
+        root = QVBoxLayout(); root.setAlignment(Qt.AlignCenter)
+        root.setSpacing(16); root.setContentsMargins(50,30,50,30); self.setLayout(root)
+        root.addStretch()
+        title = QLabel("🎮 Game Mode"); title.setAlignment(Qt.AlignCenter)
+        title.setProperty("class","main-title"); root.addWidget(title)
+        if self.saved_state:
+            li = self.saved_state.get("current_level_index",0)
+            sd_name = {0:"Easy",1:"Medium",2:"Hard"}.get(self.saved_state.get("current_sub_difficulty",0),"Easy")
+            status = QLabel(f"🔄  Resuming at Level {li+1} · {sd_name}")
+            status.setStyleSheet("color:#27AE60;font-weight:bold;")
+        else:
+            status = QLabel("Starting fresh — Level 1 · Easy")
+        status.setAlignment(Qt.AlignCenter); status.setProperty("class","subtitle"); root.addWidget(status)
+        rules = QLabel("How it works:\n• 2 correct in a row → harder sub-difficulty\n"
+                       "• Complete Hard → promotion test for next level\n"
+                       "• 3 wrong/skips → step down a level\n"
+                       "• 90 seconds · correct answers add 3s · wrong cost 1s")
+        rules.setWordWrap(True); rules.setProperty("class","subtitle"); rules.setMaximumWidth(500)
+        root.addWidget(rules, alignment=Qt.AlignCenter); root.addSpacing(16)
+        self.start_btn = QPushButton("🚀  Start Game")
+        self.start_btn.setMinimumSize(260,70); self.start_btn.setProperty("class","menu-button")
+        self.start_btn.setAccessibleName("Start Game Mode"); self.start_btn.clicked.connect(self._on_start)
+        root.addWidget(self.start_btn, alignment=Qt.AlignCenter); root.addStretch()
+        QTimer.singleShot(200, self.start_btn.setFocus)
+
+    def _speak_intro(self):
+        if self.window and not self.window.is_muted and self.tts:
+            pfx = f"Resuming at Level {self.saved_state.get('current_level_index',0)+1}. " if self.saved_state else ""
+            QTimer.singleShot(400, lambda: self.tts.speak(pfx + "Game Mode ready. Press Start Game."))
+
+    def _on_start(self):
+        if self.tts: self.tts.stop()
+        self.on_start()
+
+    def cleanup(self):
+        if self.tts: self.tts.stop()
+
+
+# ---------------------------------------------------------------------------
+# GameModeWidget
+# ---------------------------------------------------------------------------
+
+class GameModeWidget(QWidget):
+    """Active 90-second adaptive game session."""
+
+    def __init__(self, session, window, tts, on_session_end):
+        super().__init__()
+        self.session = session; self.window = window; self.tts = tts
+        self.on_session_end = on_session_end
+        self._active = True; self._question_start_time = None
+        self._current_answer = None; self._current_config = None
+        self.setAccessibleName("Game Mode Active"); self._init_ui(); self._load_next_question()
+
+    def _init_ui(self):
+        root = QVBoxLayout(); root.setContentsMargins(20,8,20,8); root.setSpacing(6); self.setLayout(root)
+        top = QHBoxLayout()
+        self.level_lbl = QLabel(""); self.level_lbl.setProperty("class","subtitle")
+        self.level_lbl.setFont(QFont("Arial",13,QFont.Bold)); top.addWidget(self.level_lbl, alignment=Qt.AlignLeft)
+        self.phase_lbl = QLabel(""); self.phase_lbl.setProperty("class","subtitle")
+        self.phase_lbl.setAlignment(Qt.AlignCenter); top.addWidget(self.phase_lbl)
+        self.qcount_lbl = QLabel(""); self.qcount_lbl.setProperty("class","subtitle")
+        self.qcount_lbl.setAlignment(Qt.AlignRight); top.addWidget(self.qcount_lbl, alignment=Qt.AlignRight)
+        root.addLayout(top)
+        self.timer_bar = QProgressBar()
+        self.timer_bar.setMaximum(self.session.session_time); self.timer_bar.setMinimum(0)
+        self.timer_bar.setValue(self.session.session_time); self.timer_bar.setTextVisible(True)
+        self.timer_bar.setFormat("%vs"); self.timer_bar.setFixedHeight(18)
+        self.timer_bar.setAccessibleName(""); self.timer_bar.setAccessibleDescription(""); root.addWidget(self.timer_bar)
+        self.type_lbl = QLabel(""); self.type_lbl.setAlignment(Qt.AlignCenter)
+        self.type_lbl.setProperty("class","main-title"); root.addWidget(self.type_lbl)
+        root.addStretch(1)
+        self.question_lbl = QLabel(""); self.question_lbl.setAlignment(Qt.AlignCenter)
+        self.question_lbl.setWordWrap(True); self.question_lbl.setProperty("class","question-label")
+        self.question_lbl.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred); root.addWidget(self.question_lbl)
+        root.addStretch(1)
+        input_row = QHBoxLayout(); input_row.setSpacing(10); input_row.setAlignment(Qt.AlignCenter)
+        self.input_box = QLineEdit(); self.input_box.setMinimumSize(220,55); self.input_box.setMaximumWidth(320)
+        self.input_box.setAlignment(Qt.AlignCenter); self.input_box.setFont(QFont("Arial",16))
+        self.input_box.setProperty("class","answer-input"); self.input_box.setAccessibleName(tr("Answer input"))
+        self.input_box.setValidator(QRegExpValidator(QRegExp(r"-?\d*\.?\d*")))
+        self.input_box.returnPressed.connect(self._check_answer); input_row.addWidget(self.input_box)
+        self.submit_btn = QPushButton("✓  Submit"); self.submit_btn.setMinimumSize(120,55)
+        self.submit_btn.setProperty("class","menu-button"); self.submit_btn.setAccessibleName("Submit answer")
+        self.submit_btn.clicked.connect(self._check_answer); input_row.addWidget(self.submit_btn)
+        root.addLayout(input_row); root.addSpacing(8)
+        self.skip_btn = QPushButton("⏭  Skip"); self.skip_btn.setMinimumSize(160,44)
+        self.skip_btn.setProperty("class","footer-button"); self.skip_btn.setFont(QFont("Arial",13))
+        self.skip_btn.setAccessibleName("Skip this question"); self.skip_btn.clicked.connect(self._on_skip)
+        root.addWidget(self.skip_btn, alignment=Qt.AlignCenter)
+        self.feedback_lbl = QLabel(""); self.feedback_lbl.setAlignment(Qt.AlignCenter)
+        self.feedback_lbl.setFont(QFont("Arial",20,QFont.Bold)); self.feedback_lbl.setFixedHeight(46)
+        root.addWidget(self.feedback_lbl); root.addStretch(1)
+
+    def _load_next_question(self):
+        if not self._active: return
+        self._current_config = self.session.get_next_question_config()
+        if self._current_config is None: self._finish(); return
+        processor = self.session.build_processor(self._current_config)
+        if processor.df is None or processor.df.empty:
+            self.session.skip_question(self._current_config); QTimer.singleShot(0, self._load_next_question); return
+        question_text, self._current_answer = processor.get_questions()
+        if question_text == "No questions found." or self._current_answer is None:
+            self.session.skip_question(self._current_config); QTimer.singleShot(0, self._load_next_question); return
+        sd = {0:"Easy",1:"Medium",2:"Hard"}.get(self.session.current_sub_difficulty,"Easy")
+        self.level_lbl.setText(f"🎮 {self.session.level_name()} · {sd}")
+        ph = self._current_config.get("phase","normal")
+        self.phase_lbl.setText("🔝 Promotion Test" if ph=="promotion_test" else "")
+        self.qcount_lbl.setText(f"Q{self.session.question_count+1}")
+        self.type_lbl.setText(self._current_config["label"])
+        ln = len(question_text)
+        self.question_lbl.setStyleSheet("font-size:14pt;" if ln>120 else "font-size:18pt;" if ln>80 else "")
+        self.question_lbl.setText(question_text)
+        self.feedback_lbl.setText(""); self.input_box.clear()
+        self.input_box.setEnabled(True); self.submit_btn.setEnabled(True); self.skip_btn.setEnabled(True)
+        self._question_start_time = None
+        audio_on = self.window and not self.window.is_muted
+        if audio_on and self.tts:
+            tts_text = f"{question_text}. {tr('Type your answer')}"
+            QTimer.singleShot(len(tts_text)*70+1500, self._on_tts_done); self.tts.speak(tts_text)
+        else:
+            self._on_tts_done()
+        QTimer.singleShot(100, self.input_box.setFocus)
+
+    def _on_tts_done(self):
+        if self._active: self._question_start_time = time()
+
+    def _check_answer(self):
+        if not self._active: return
+        user_text = self.input_box.text().strip()
+        if not user_text: self.input_box.setFocus(); return
+        try: is_correct = (float(user_text) == float(self._current_answer))
+        except (TypeError, ValueError):
+            self.feedback_lbl.setText('<span style="color:#E74C3C;">✗ Invalid</span>'); self.input_box.setFocus(); return
+        elapsed = (time()-self._question_start_time) if self._question_start_time else 0.0
+        score   = self.session.submit_answer(self._current_config, is_correct, elapsed)
+        self.input_box.setEnabled(False); self.submit_btn.setEnabled(False); self.skip_btn.setEnabled(False)
+        if is_correct:
+            self.window.time_remaining = min(self.window.time_remaining+3, self.session.session_time)
+        else:
+            self.window.time_remaining = max(0, self.window.time_remaining-1)
+        self.update_timer(self.window.time_remaining)
+        from question.warmup import save_game_session; save_game_session(self.session.save_state())
+        if is_correct:
+            emoji, tier = SCORE_INFO.get(score, ("✓",""))
+            self.feedback_lbl.setText(f'<span style="color:#27AE60;">{emoji} {tier}</span>')
+            if self.tts and not self.window.is_muted: QTimer.singleShot(50, lambda t=tier: self.tts.speak(t))
+            QTimer.singleShot(1200, self._load_next_question)
+        else:
+            self.feedback_lbl.setText('<span style="color:#E74C3C;">✗ Wrong</span>')
+            if self.tts and not self.window.is_muted: QTimer.singleShot(50, lambda: self.tts.speak("Wrong"))
+            QTimer.singleShot(900, self._load_next_question)
+
+    def _on_skip(self):
+        if not self._active: return
+        self.session.skip_question(self._current_config)
+        self.window.time_remaining = max(0, self.window.time_remaining-2)
+        self.update_timer(self.window.time_remaining)
+        from question.warmup import save_game_session; save_game_session(self.session.save_state())
+        self.feedback_lbl.setText('<span style="color:#95A5A6;">⏭ Skipped</span>')
+        self.input_box.setEnabled(False); self.submit_btn.setEnabled(False); self.skip_btn.setEnabled(False)
+        QTimer.singleShot(700, self._load_next_question)
+
+    def update_timer(self, secs):
+        self.timer_bar.setValue(secs)
+        c = "#1D9E75" if secs>30 else "#EF9F27" if secs>15 else "#E24B4A"
+        self.timer_bar.setStyleSheet(f"QProgressBar::chunk{{background-color:{c};border-radius:4px;}}")
+
+    def _finish(self):
+        self._active = False
+        if self.tts: self.tts.stop()
+        self.on_session_end()
+
+    def cleanup(self):
+        self._active = False
+        if self.tts: self.tts.stop()
+
+
+# ---------------------------------------------------------------------------
+# GameModeReportWidget
+# ---------------------------------------------------------------------------
+
+class GameModeReportWidget(QWidget):
+    """Post-session summary with updated ranking and Play Again button."""
+
+    def __init__(self, session, window, tts, on_play_again):
+        super().__init__()
+        self.session = session; self.window = window; self.tts = tts; self.on_play_again = on_play_again
+        self.setAccessibleName("Game Mode Results"); self._init_ui(); self._speak_summary()
+
+    def _init_ui(self):
+        root = QVBoxLayout(); root.setContentsMargins(40,16,40,16); root.setSpacing(10); self.setLayout(root)
+        title = QLabel("🏆 Session Complete!"); title.setAlignment(Qt.AlignCenter)
+        title.setProperty("class","main-title"); root.addWidget(title)
+        acc = self.session.accuracy_pct(); lvl = self.session.highest_level_reached+1
+        stats = QLabel(f"Questions: {self.session.question_count}   ·   Accuracy: {acc}%   ·   Highest Level: {lvl}")
+        stats.setAlignment(Qt.AlignCenter); stats.setProperty("class","subtitle"); root.addWidget(stats)
+        div = QFrame(); div.setFrameShape(QFrame.HLine); root.addWidget(div)
+        updated = self.session.get_ranked_results_updated()
+        scroll = QScrollArea(); scroll.setWidgetResizable(True); scroll.setFrameShape(QFrame.NoFrame)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        lw = QWidget(); ll = QVBoxLayout(lw); ll.setSpacing(4); ll.setContentsMargins(0,0,0,0)
+        for rank, entry in enumerate(updated, 1):
+            lbl = entry["label"]; score = entry["score"]; gained = entry.get("gained",0.0)
+            key = 1.0 if score>=1.0 else 0.5 if score>=0.5 else 0.2 if score>0 else 0.0
+            colour = SCORE_COLOURS.get(key,"#95A5A6"); gained_txt = f"+{gained:.1f}" if gained>0 else "–"
+            row = QHBoxLayout(); row.setSpacing(10)
+            rl = QLabel(f"#{rank}"); rl.setFixedWidth(32); rl.setFont(QFont("Arial",12,QFont.Bold)); rl.setAlignment(Qt.AlignCenter)
+            tl = QLabel(lbl); tl.setFont(QFont("Arial",12)); tl.setSizePolicy(QSizePolicy.Expanding,QSizePolicy.Preferred)
+            gl = QLabel(gained_txt); gl.setFont(QFont("Arial",12,QFont.Bold)); gl.setStyleSheet(f"color:{colour};"); gl.setFixedWidth(44); gl.setAlignment(Qt.AlignRight)
+            sl = QLabel(f"{score:.1f}pt"); sl.setFont(QFont("Arial",12)); sl.setFixedWidth(48); sl.setAlignment(Qt.AlignRight)
+            for w in (rl,tl,gl,sl): row.addWidget(w)
+            rw = QWidget(); rw.setLayout(row); rw.setStyleSheet("QWidget{border-bottom:1px solid rgba(128,128,128,0.2);padding:3px 0;}"); ll.addWidget(rw)
+        ll.addStretch(); scroll.setWidget(lw); root.addWidget(scroll)
+        self.play_btn = QPushButton("🔄  Play Again"); self.play_btn.setMinimumSize(220,65)
+        self.play_btn.setProperty("class","menu-button"); self.play_btn.setAccessibleName("Play Again")
+        self.play_btn.clicked.connect(self._on_play_again); root.addWidget(self.play_btn, alignment=Qt.AlignCenter)
+        QTimer.singleShot(300, self.play_btn.setFocus)
+
+    def _speak_summary(self):
+        if not (self.window and not self.window.is_muted and self.tts): return
+        msg = f"Session complete! {self.session.accuracy_pct()} percent accuracy. You reached Level {self.session.highest_level_reached+1}. Great effort!"
+        QTimer.singleShot(600, lambda: self.tts.speak(msg))
+
+    def _on_play_again(self):
+        if self.tts: self.tts.stop()
+        self.on_play_again()
+
+    def cleanup(self):
+        if self.tts: self.tts.stop()

--- a/question/warmup.py
+++ b/question/warmup.py
@@ -1,0 +1,358 @@
+"""question/warmup.py — Warmup session + adaptive Game Mode session logic."""
+
+import os, json, pandas as pd
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+WARMUP_PROFILE_FILE  = "warmup_profile.json"
+GAME_SESSION_FILE    = "game_session.json"
+
+WARMUP_SEQUENCE = [
+    {"label": "1-digit Addition",          "q_type": "addition",       "digits": "1d",       "difficulty": 0},
+    {"label": "2-digit Addition",          "q_type": "addition",       "digits": "2d",       "difficulty": 1},
+    {"label": "1-digit Subtraction",       "q_type": "subtraction",    "digits": "1d",       "difficulty": 0},
+    {"label": "2-digit Subtraction",       "q_type": "subtraction",    "digits": "2d",       "difficulty": 1},
+    {"label": "1-digit Multiplication",    "q_type": "multiplication", "digits": "1d",       "difficulty": 0},
+    {"label": "2×1-digit Multiplication",  "q_type": "multiplication", "digits": "2d",       "difficulty": 1},
+    {"label": "2×2-digit Multiplication",  "q_type": "multiplication", "digits": "3d",       "difficulty": 2},
+    {"label": "1-digit Division",          "q_type": "division",       "digits": "1d",       "difficulty": 0},
+    {"label": "2÷1-digit Division",        "q_type": "division",       "digits": "2d+1d",    "difficulty": 1},
+    {"label": "Word Problem",              "q_type": "story",          "digits": "1d",       "difficulty": 0},
+    {"label": "Time Problem",              "q_type": "time",           "digits": "2d",       "difficulty": 1},
+    {"label": "Currency Problem",          "q_type": "currency",       "digits": "2d",       "difficulty": 1},
+    {"label": "Mixed Operations",          "q_type": "mixed",          "digits": "2d+2d+1d", "difficulty": 3},
+]
+
+MAX_WRONG = MAX_SKIPS = 2
+AUTO_SKIP_SECONDS      = 30
+SCORE_FAST_THRESHOLD   = 4.0
+SCORE_MEDIUM_THRESHOLD = 12.0
+SCORE_INFO = {1.0: ("🌟","Very Fast"), 0.5: ("👍","Good"), 0.2: ("🐢","Slow"), 0.0: ("✗","Missed")}
+SCORE_COLOURS = {1.0:"#27AE60", 0.5:"#D4AC0D", 0.2:"#E67E22", 0.0:"#95A5A6"}
+
+# ── Warmup persistence ────────────────────────────────────────────────────────
+
+def has_completed_warmup():
+    if not os.path.exists(WARMUP_PROFILE_FILE): return False
+    try:
+        with open(WARMUP_PROFILE_FILE, "r", encoding="utf-8") as f:
+            return bool(json.load(f).get("completed", False))
+    except Exception: return False
+
+def save_warmup_profile(ranked):
+    with open(WARMUP_PROFILE_FILE, "w", encoding="utf-8") as f:
+        json.dump({"completed": True, "ranked": ranked}, f, indent=2, ensure_ascii=False)
+
+def load_warmup_profile():
+    if not os.path.exists(WARMUP_PROFILE_FILE): return None
+    try:
+        with open(WARMUP_PROFILE_FILE, "r", encoding="utf-8") as f:
+            return json.load(f).get("ranked")
+    except Exception: return None
+
+# ── Game session persistence ──────────────────────────────────────────────────
+
+def save_game_session(state):
+    with open(GAME_SESSION_FILE, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, ensure_ascii=False)
+
+def load_game_session():
+    if not os.path.exists(GAME_SESSION_FILE): return None
+    try:
+        with open(GAME_SESSION_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception: return None
+
+def clear_game_session():
+    if os.path.exists(GAME_SESSION_FILE):
+        os.remove(GAME_SESSION_FILE)
+
+# ── WarmupSession ─────────────────────────────────────────────────────────────
+
+class WarmupSession:
+    def __init__(self):
+        self.step_index  = 0
+        self.wrong_count = 0
+        self.skip_count  = 0
+        self.scores      = {}
+        self._full_df    = None
+        self._load_full_df()
+
+    def _load_full_df(self):
+        fp = os.path.join(os.getcwd(), "question", "game_ques.xlsx")
+        df = pd.read_excel(fp)
+        df["type_lower"] = df["type"].astype(str).str.lower().str.strip()
+        df["digits_str"] = df["digits"].astype(str).str.lower().str.strip()
+        df["difficulty"] = pd.to_numeric(df["difficulty"], errors="coerce")
+        self._full_df = df
+
+    def _build_processor(self, step):
+        from question.loader import QuestionProcessor
+        q, d, diff = step["q_type"].lower(), step["digits"].lower(), step["difficulty"]
+        mask = (self._full_df["type_lower"]==q)&(self._full_df["digits_str"]==d)&(self._full_df["difficulty"]==diff)
+        filtered = self._full_df[mask].copy().reset_index(drop=True)
+        if filtered.empty:
+            mask2 = (self._full_df["type_lower"]==q)&(self._full_df["difficulty"]==diff)
+            filtered = self._full_df[mask2].copy().reset_index(drop=True)
+        if filtered.empty:
+            filtered = self._full_df[self._full_df["type_lower"]==q].copy().reset_index(drop=True)
+        p = QuestionProcessor(q, diff, disable_dda=True, is_game_mode=True)
+        p.df = filtered; p._skip_process_file = True
+        return p
+
+    def total_steps(self): return len(WARMUP_SEQUENCE)
+    def current_step(self): return WARMUP_SEQUENCE[self.step_index] if self.step_index < len(WARMUP_SEQUENCE) else None
+    def get_current_processor(self):
+        s = self.current_step(); return self._build_processor(s) if s else None
+
+    def is_complete(self):
+        return self.step_index >= len(WARMUP_SEQUENCE) or self.wrong_count >= MAX_WRONG or self.skip_count >= MAX_SKIPS
+
+    def completion_reason(self):
+        if self.wrong_count >= MAX_WRONG: return "wrong"
+        if self.skip_count >= MAX_SKIPS:  return "skipped"
+        return "complete"
+
+    def submit_answer(self, is_correct, elapsed):
+        step = self.current_step()
+        if step is None: return 0.0
+        score = 0.0 if not is_correct else (1.0 if elapsed<=SCORE_FAST_THRESHOLD else (0.5 if elapsed<=SCORE_MEDIUM_THRESHOLD else 0.2))
+        if not is_correct: self.wrong_count += 1
+        self.scores[step["label"]] = score
+        self.step_index += 1
+        return score
+
+    def skip_question(self):
+        step = self.current_step()
+        if step:
+            self.scores[step["label"]] = 0.0
+            self.skip_count += 1; self.step_index += 1
+
+    def get_ranked_results(self):
+        seq = {s["label"]: s for s in WARMUP_SEQUENCE}
+        result = []
+        for label, score in self.scores.items():
+            s = seq.get(label, {})
+            result.append({"label": label, "score": score,
+                           "q_type": s.get("q_type","addition"), "digits": s.get("digits","1d")})
+        return sorted(result, key=lambda x: x["score"], reverse=True)
+
+    def correct_count(self): return sum(1 for s in self.scores.values() if s > 0)
+
+
+# ── GameModeSession ───────────────────────────────────────────────────────────
+
+class GameModeSession:
+    SUB_DIFF_NAMES = {0: "Easy", 1: "Medium", 2: "Hard"}
+    session_time = 90
+
+    def __init__(self, ranked_list, saved_state=None):
+        self.ranked  = ranked_list or []
+        # Build label→WARMUP_SEQUENCE lookup for backward-compat (old profiles lack q_type)
+        self._seq_lookup = {s["label"]: s for s in WARMUP_SEQUENCE}
+        # Back-fill missing q_type / digits from WARMUP_SEQUENCE
+        for entry in self.ranked:
+            if not entry.get("q_type"):
+                seq = self._seq_lookup.get(entry["label"], {})
+                entry["q_type"] = seq.get("q_type", "addition")
+                entry["digits"] = seq.get("digits", "1d")
+        self.levels  = [self.ranked[i:i+2] for i in range(0, len(self.ranked), 2)]
+        self.game_active = True
+
+        # Progressive state
+        self.current_level_index   = 0
+        self.current_sub_difficulty = 0
+        self.type_rotation          = 0
+        self.phase                  = "normal"   # "normal" | "promotion_test"
+        self.promotion_correct      = 0
+        self.promotion_wrong        = 0
+        self.consecutive_correct    = 0
+        self.consecutive_wrong      = 0
+        self.questions_at_sub_diff  = 0
+
+        # Scoring
+        self.accumulated_points  = {e["label"]: 0.0 for e in self.ranked}
+        self.question_count      = 0
+        self.correct_count       = 0
+        self.highest_level_reached = 0
+
+        # Shared DataFrame (loaded once, reused per question)
+        self._full_df = None
+        self._load_df()
+
+        if saved_state:
+            self._restore_state(saved_state)
+
+    def _load_df(self):
+        fp = os.path.join(os.getcwd(), "question", "game_ques.xlsx")
+        df = pd.read_excel(fp)
+        df["type_lower"] = df["type"].astype(str).str.lower().str.strip()
+        df["digits_str"] = df["digits"].astype(str).str.lower().str.strip()
+        df["difficulty"] = pd.to_numeric(df["difficulty"], errors="coerce")
+        self._full_df = df
+
+    # ── Question config ───────────────────────────────────────────────────────
+
+    def _current_types(self):
+        idx = min(self.current_level_index, len(self.levels)-1)
+        return self.levels[idx] if self.levels else []
+
+    def _next_level_types(self):
+        idx = self.current_level_index + 1
+        return self.levels[idx] if idx < len(self.levels) else []
+
+    def get_next_question_config(self):
+        if self.phase == "promotion_test":
+            next_idx = self.current_level_index + 1
+            if next_idx < len(self.levels):
+                types = self.levels[next_idx]
+                if types:
+                    entry = types[self.type_rotation % len(types)]
+                    q_type = entry.get("q_type") or self._seq_lookup.get(entry["label"],{}).get("q_type","addition")
+                    digits = entry.get("digits") or self._seq_lookup.get(entry["label"],{}).get("digits","1d")
+                    return {"q_type": q_type, "digits": digits, "difficulty": 0,
+                            "label": entry["label"], "phase": self.phase}
+            return None
+        types = self._current_types()
+        if not types: return None
+        entry  = types[self.type_rotation % len(types)]
+        q_type = entry.get("q_type") or self._seq_lookup.get(entry["label"],{}).get("q_type","addition")
+        digits = entry.get("digits") or self._seq_lookup.get(entry["label"],{}).get("digits","1d")
+        return {"q_type": q_type, "digits": digits,
+                "difficulty": self.current_sub_difficulty,
+                "label": entry["label"], "phase": self.phase}
+
+    def build_processor(self, config):
+        from question.loader import QuestionProcessor
+        q_type = config["q_type"].lower()
+        digits = config.get("digits", "").lower().strip()
+        diff   = config["difficulty"]
+        
+        # Match EXACTLY by q_type and digits so "1-digit addition" never asks 2-digit questions
+        mask = (self._full_df["type_lower"]==q_type) & (self._full_df["digits_str"]==digits)
+        filtered = self._full_df[mask].copy().reset_index(drop=True)
+        if filtered.empty:
+            mask2 = (self._full_df["type_lower"]==q_type) & (self._full_df["difficulty"]==diff)
+            filtered = self._full_df[mask2].copy().reset_index(drop=True)
+            if filtered.empty:
+                filtered = self._full_df[self._full_df["type_lower"]==q_type].copy().reset_index(drop=True)
+                
+        p = QuestionProcessor(q_type, diff, disable_dda=True, is_game_mode=True)
+        p.df = filtered; p._skip_process_file = True
+        return p
+
+    # ── Scoring ───────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def calc_score(is_correct, elapsed):
+        if not is_correct: return 0.0
+        if elapsed <= SCORE_FAST_THRESHOLD:   return 1.0
+        if elapsed <= SCORE_MEDIUM_THRESHOLD: return 0.5
+        return 0.2
+
+    def _advance_rotation(self, types):
+        if types: self.type_rotation = (self.type_rotation + 1) % len(types)
+
+    def submit_answer(self, config, is_correct, elapsed):
+        score = self.calc_score(is_correct, elapsed)
+        label = config.get("label","")
+        if label in self.accumulated_points: self.accumulated_points[label] += score
+        self.question_count += 1
+        if is_correct: self.correct_count += 1
+        types = self._next_level_types() if self.phase=="promotion_test" else self._current_types()
+        self._advance_rotation(types)
+        self.questions_at_sub_diff += 1
+        self._apply_progression(is_correct)
+        return score
+
+    def skip_question(self, config):
+        label = config.get("label","")
+        # skip = 0 pts (no accumulation)
+        self.question_count += 1
+        self._advance_rotation(self._current_types())
+        self.questions_at_sub_diff += 1
+        self._apply_progression(False)
+
+    # ── Progression ───────────────────────────────────────────────────────────
+
+    def _apply_progression(self, is_correct):
+        if self.phase == "promotion_test":
+            self._handle_promotion(is_correct); return
+        if is_correct:
+            self.consecutive_correct += 1; self.consecutive_wrong = 0
+            if self.consecutive_correct >= 2 and self.questions_at_sub_diff >= 3:
+                self._advance_sub_diff()
+        else:
+            self.consecutive_wrong += 1; self.consecutive_correct = 0
+            if self.consecutive_wrong >= 3: self._demote()
+
+    def _advance_sub_diff(self):
+        self.consecutive_correct = 0; self.questions_at_sub_diff = 0
+        if self.current_sub_difficulty < 2:
+            self.current_sub_difficulty += 1
+        else:
+            if self._next_level_types():
+                self.phase = "promotion_test"
+                self.promotion_correct = self.promotion_wrong = 0
+                self.type_rotation = 0
+
+    def _handle_promotion(self, is_correct):
+        if is_correct: self.promotion_correct += 1
+        else:          self.promotion_wrong   += 1
+        total = self.promotion_correct + self.promotion_wrong
+        if self.promotion_correct >= 2:  self._promote()
+        elif self.promotion_wrong >= 2:   self._fail_promotion()
+        elif total >= 3:                  self._fail_promotion()
+
+    def _promote(self):
+        self.current_level_index   += 1
+        self.current_sub_difficulty = 0
+        self.phase = "normal"
+        self.promotion_correct = self.promotion_wrong = 0
+        self.consecutive_correct = self.consecutive_wrong = 0
+        self.questions_at_sub_diff = self.type_rotation = 0
+        if self.current_level_index > self.highest_level_reached:
+            self.highest_level_reached = self.current_level_index
+
+    def _fail_promotion(self):
+        self.current_sub_difficulty = 2; self.phase = "normal"
+        self.promotion_correct = self.promotion_wrong = 0
+        self.consecutive_correct = self.questions_at_sub_diff = self.type_rotation = 0
+
+    def _demote(self):
+        self.consecutive_wrong = self.consecutive_correct = 0
+        self.questions_at_sub_diff = self.type_rotation = 0; self.phase = "normal"
+        if self.current_level_index > 0:
+            self.current_level_index  -= 1; self.current_sub_difficulty = 2
+        else:
+            self.current_sub_difficulty = 0
+
+    # ── Results ───────────────────────────────────────────────────────────────
+
+    def get_ranked_results_updated(self):
+        result = []
+        for entry in self.ranked:
+            lbl    = entry["label"]
+            gained = self.accumulated_points.get(lbl, 0.0)
+            result.append({**entry, "score": entry.get("score",0.0)+gained, "gained": gained,
+                           "original_score": entry.get("score",0.0)})
+        return sorted(result, key=lambda x: x["score"], reverse=True)
+
+    def accuracy_pct(self):
+        return int((self.correct_count / max(self.question_count,1)) * 100)
+
+    def level_name(self): return f"Level {self.current_level_index + 1}"
+    def sub_diff_name(self): return self.SUB_DIFF_NAMES.get(self.current_sub_difficulty, "Easy")
+
+    # ── State persistence ─────────────────────────────────────────────────────
+
+    def save_state(self):
+        return {k: getattr(self,k) for k in (
+            "current_level_index","current_sub_difficulty","type_rotation",
+            "phase","promotion_correct","promotion_wrong",
+            "consecutive_correct","consecutive_wrong","questions_at_sub_diff",
+            "accumulated_points","question_count","correct_count","highest_level_reached"
+        )}
+
+    def _restore_state(self, state):
+        for k, v in state.items():
+            if hasattr(self, k): setattr(self, k, v)

--- a/warmup_profile.json
+++ b/warmup_profile.json
@@ -1,0 +1,61 @@
+{
+  "completed": true,
+  "ranked": [
+    {
+      "label": "1-digit Multiplication",
+      "score": 8.7,
+      "q_type": "multiplication",
+      "digits": "1d",
+      "gained": 7.7,
+      "original_score": 1.0
+    },
+    {
+      "label": "1-digit Addition",
+      "score": 5.5,
+      "q_type": "addition",
+      "digits": "1d",
+      "gained": 4.5,
+      "original_score": 1.0
+    },
+    {
+      "label": "2-digit Addition",
+      "score": 2.4,
+      "q_type": "addition",
+      "digits": "2d",
+      "gained": 1.9,
+      "original_score": 0.5
+    },
+    {
+      "label": "2-digit Subtraction",
+      "score": 2.0,
+      "q_type": "subtraction",
+      "digits": "2d",
+      "gained": 1.5,
+      "original_score": 0.5
+    },
+    {
+      "label": "1-digit Subtraction",
+      "score": 1.0,
+      "q_type": "subtraction",
+      "digits": "1d",
+      "gained": 0.0,
+      "original_score": 1.0
+    },
+    {
+      "label": "2×1-digit Multiplication",
+      "score": 0.0,
+      "q_type": "multiplication",
+      "digits": "2d",
+      "gained": 0.0,
+      "original_score": 0.0
+    },
+    {
+      "label": "2×2-digit Multiplication",
+      "score": 0.0,
+      "q_type": "multiplication",
+      "digits": "3d",
+      "gained": 0.0,
+      "original_score": 0.0
+    }
+  ]
+}


### PR DESCRIPTION
Description
Replaces the manual Game Mode difficulty selector with a fully adaptive, personalized progression system based on user performance.

Key Changes
**Warmup Match Onboarding:** Added a mandatory, one-time 13-question assessment for first-time players. Ranks user proficiency across different math skills based on speed and accuracy.

**Dynamic Game Mode:** Replaced the static menu with an automated 90-second adaptive session. Groups skills into "Levels" and dynamically adjusts difficulty based on consecutive correct/incorrect streaks.

**Save & Resume Persistence:** Game states and proficiency ranks are natively saved (warmup_profile.json & game_session.json), allowing players to pause and resume at their exact level.

**Session Reports:** Added live post-game analytics screens highlighting rank improvements and points gained after every session.

**Core Refactoring:** Rewrote routing in main.py and hardened question filtering logic to ensure question digits strictly align with the user's specific skill level progression.